### PR TITLE
Follow時にボタンメッセージを送れるようにした

### DIFF
--- a/app-adapter/src/gateway/send_message.rs
+++ b/app-adapter/src/gateway/send_message.rs
@@ -36,10 +36,12 @@ impl SendMessageGateway for HttpClientRepositoryImpl<SendMessage> {
                 // todo 作成は上のレイヤーでする
                 let create_message = CreateSendMessage::from_event(event);
                 let requests = create_message.into_chunked_requests(line_user_auth.auth_id.0);
+                println!("Requests: {:?}", requests);
                 self.send_line_messages(line_user_auth.auth_token, sender, requests)
                     .await?
             }
         };
+        println!("messages: {:?}", messages);
         Ok(messages)
     }
 }
@@ -82,6 +84,7 @@ impl HttpClientRepositoryImpl<SendMessage> {
         sender: Option<NewSendSender>,
         message_request: ReplySendMessageRequest,
     ) -> anyhow::Result<NewSendMessages> {
+        println!("message_request: {:?}", message_request);
         let body = self
             .client
             .post("https://api.line.me/v2/bot/message/reply")
@@ -92,7 +95,7 @@ impl HttpClientRepositoryImpl<SendMessage> {
             .await?
             .text()
             .await?;
-
+        println!("body: {:?}", body);
         let sent_messages: SentMessagesResponse = serde_json::from_str(&body).map_err(|_| {
             anyhow!(GatewayError::FailedConvertResponse(
                 body.to_string(),

--- a/app-adapter/src/gateway/send_message.rs
+++ b/app-adapter/src/gateway/send_message.rs
@@ -33,7 +33,6 @@ impl SendMessageGateway for HttpClientRepositoryImpl<SendMessage> {
                 /*
                  * lineのメッセージを作成する
                  */
-                // todo 作成は上のレイヤーでする
                 let create_message = CreateSendMessage::from_event(event);
                 let requests = create_message.into_chunked_requests(line_user_auth.auth_id.0);
                 self.send_line_messages(line_user_auth.auth_token, sender, requests)

--- a/app-adapter/src/gateway/send_message.rs
+++ b/app-adapter/src/gateway/send_message.rs
@@ -95,7 +95,6 @@ impl HttpClientRepositoryImpl<SendMessage> {
             .await?
             .text()
             .await?;
-        println!("body: {:?}", body);
         let sent_messages: SentMessagesResponse = serde_json::from_str(&body).map_err(|_| {
             anyhow!(GatewayError::FailedConvertResponse(
                 body.to_string(),

--- a/app-adapter/src/gateway/send_message.rs
+++ b/app-adapter/src/gateway/send_message.rs
@@ -36,7 +36,6 @@ impl SendMessageGateway for HttpClientRepositoryImpl<SendMessage> {
                 // todo 作成は上のレイヤーでする
                 let create_message = CreateSendMessage::from_event(event);
                 let requests = create_message.into_chunked_requests(line_user_auth.auth_id.0);
-                println!("Requests: {:?}", requests);
                 self.send_line_messages(line_user_auth.auth_token, sender, requests)
                     .await?
             }

--- a/app-adapter/src/model/message/send_message/request.rs
+++ b/app-adapter/src/model/message/send_message/request.rs
@@ -45,28 +45,32 @@ impl CreateSendMessage {
             NewEvent::Follow(e) => {
                 let messages: Vec<SendMessageContentRequest> = vec![
                     SendMessageContentRequest::Text(SendMessageContentTextRequest {
-                        text: "ようこそ。\nRustで開発したLINE botです。\n\n以下のボタンからご希望のオプションを選択してください。".to_string(),
+                        text: "ようこそ。\nRustで開発したLINE botです。\n\n以下のボタンからご希望のメニューを選択してください。".to_string(),
                         emojis: None,
                         quote_token: None,
                     }),
                     SendMessageContentRequest::Template(SendMessageContentTemplateRequest {
-                        alt_text: "オプションを選択してください。".to_string(),
+                        alt_text: "選択してください。".to_string(),
                         template: SendTemplateMessageContentRequest::Buttons(SendButtonsTemplateRequest {
                             thumbnail_image_url: None,
                             image_aspect_ratio: None,
                             image_size: None,
                             image_background_color: None,
                             title: None,
-                            text: "オプションを選択してください。".to_string(),
+                            text: "選択してください。".to_string(),
                             default_action: None,
                             actions: vec![
                                 SendTemplateActionRequest::Message(SendTemplateMessageActionRequest {
-                                    label: "こんにちは".to_string(),
-                                    text: "こんにちは".to_string(),
+                                    label: "Rustの基礎を学ぶ".to_string(),
+                                    text: "Rustを基礎から学ぶには、Tour of Rustがおすすめです。環境構築不要でRustを学べます。\nhttps://tourofrust.com/00_ja.html".to_string(),
                                 }),
                                 SendTemplateActionRequest::Message(SendTemplateMessageActionRequest {
-                                    label: "こんばんは".to_string(),
-                                    text: "こんばんは".to_string(),
+                                    label: "Rustの公式ドキュメントを見る".to_string(),
+                                    text: "Rustの公式ドキュメントはこちらから閲覧できます。\nhttps://www.rust-lang.org/ja".to_string(),
+                                }),
+                                SendTemplateActionRequest::Message(SendTemplateMessageActionRequest {
+                                    label: "Rustのサンプルコードを見る".to_string(),
+                                    text: "Rustのサンプルコードを見るなら、Rust by Exampleがおすすめです。\nhttps://doc.rust-jp.rs/rust-by-example-ja/index.html".to_string(),
                                 }),
                             ],
                         }),

--- a/app-adapter/src/model/message/send_message/request.rs
+++ b/app-adapter/src/model/message/send_message/request.rs
@@ -324,7 +324,6 @@ pub enum SendSendingMethodRequest {
     Push,
 }
 
-// TODO Flex Messageの実装
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(tag = "type")]
 #[serde(rename_all = "lowercase")]

--- a/app-adapter/src/model/message/send_message/request.rs
+++ b/app-adapter/src/model/message/send_message/request.rs
@@ -45,14 +45,31 @@ impl CreateSendMessage {
             NewEvent::Follow(e) => {
                 let messages: Vec<SendMessageContentRequest> = vec![
                     SendMessageContentRequest::Text(SendMessageContentTextRequest {
-                        text: "友達登録ありがとうございます！".to_string(),
+                        text: "ようこそ。\nRustで開発したLINE botです。\n\n以下のボタンからご希望のオプションを選択してください。".to_string(),
                         emojis: None,
                         quote_token: None,
                     }),
-                    SendMessageContentRequest::Text(SendMessageContentTextRequest {
-                        text: "こんにちは！PharmaXです！！".to_string(),
-                        emojis: None,
-                        quote_token: None,
+                    SendMessageContentRequest::Template(SendMessageContentTemplateRequest {
+                        alt_text: "オプションを選択してください。".to_string(),
+                        template: SendTemplateMessageContentRequest::Buttons(SendButtonsTemplateRequest {
+                            thumbnail_image_url: None,
+                            image_aspect_ratio: None,
+                            image_size: None,
+                            image_background_color: None,
+                            title: None,
+                            text: "オプションを選択してください。".to_string(),
+                            default_action: None,
+                            actions: vec![
+                                SendTemplateActionRequest::Message(SendTemplateMessageActionRequest {
+                                    label: "こんにちは".to_string(),
+                                    text: "こんにちは".to_string(),
+                                }),
+                                SendTemplateActionRequest::Message(SendTemplateMessageActionRequest {
+                                    label: "こんばんは".to_string(),
+                                    text: "こんばんは".to_string(),
+                                }),
+                            ],
+                        }),
                     }),
                 ];
                 println!("from_event messages:{:?}", &messages);
@@ -874,7 +891,7 @@ impl From<SendImageCarouselColumn> for NewSendImageCarouselColumn {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
+#[serde(tag = "type", rename_all = "camelCase")]
 pub enum SendTemplateActionRequest {
     Postback(SendTemplatePostbackActionRequest),
     Message(SendTemplateMessageActionRequest),

--- a/app-adapter/src/model/message/send_message/table.rs
+++ b/app-adapter/src/model/message/send_message/table.rs
@@ -279,7 +279,6 @@ impl From<SendSenderRoleTable> for SendSenderRole {
     }
 }
 
-// TODO Flex Messageの実装
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(tag = "type")]
 #[serde(rename_all = "lowercase")]

--- a/app-domain/src/model/line_user.rs
+++ b/app-domain/src/model/line_user.rs
@@ -3,7 +3,6 @@ use derive_new::new;
 
 #[derive(new, Debug, Clone, PartialEq, Eq)]
 pub struct LineUserProfile {
-    // todo: 文字数にバリデーションつける
     pub auth_id: LineId,
     pub display_name: String,
     pub picture_url: String,

--- a/app-domain/src/model/message/send_message.rs
+++ b/app-domain/src/model/message/send_message.rs
@@ -38,7 +38,6 @@ pub enum SendSenderRole {
     Sender,
 }
 
-// TODO Flex Messageの実装
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SendMessage {
     Text(SendMessageText),
@@ -375,7 +374,6 @@ pub enum NewSendSenderRole {
     Sender,
 }
 
-// TODO Flex Messageの実装
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum NewSendMessage {
     Text(NewSendMessageText),

--- a/app-presentation/src/model/line_webhook.rs
+++ b/app-presentation/src/model/line_webhook.rs
@@ -290,7 +290,7 @@ enum LineWebhookEventMessageContent {
 struct LineWebhookEventMessageContentText {
     id: String,
     text: String,
-    emojis: Vec<LineWebhookEventEmoji>,
+    emojis: Option<Vec<LineWebhookEventEmoji>>,
     mention: Option<LineWebhookEventMention>,
 }
 
@@ -617,6 +617,7 @@ impl From<LineWebhookEventMessageContentText> for CreateEventMessageContentText 
             text: s.text,
             emojis: s
                 .emojis
+                .unwrap_or_default()
                 .iter()
                 .map(|e| CreateEventEmoji {
                     index: e.index,


### PR DESCRIPTION
## 実装内容
- Follow時にボタンメッセージが送られるようにした
- ボタンの内容としては、Rustを学ぶのにおすすめの学習コンテンツを閲覧できるようにした（画像参照）
![IMG_1607 (1)](https://github.com/user-attachments/assets/8b9803ea-7d68-4f9c-b2e2-604fbb98bb6c)
![IMG_1608](https://github.com/user-attachments/assets/7d13eaad-72e6-412d-9287-4c1878b211b9)

## 備考
- TODOコメントなどの削除は別PRで行う